### PR TITLE
Added New Location

### DIFF
--- a/locations.txt
+++ b/locations.txt
@@ -20,6 +20,8 @@ Denver, Colorado
 
 Moscow, Russia
 
+GWagwalada, Nigeria
+
 Milwaukee, Wisconsin
 
 Elmhurst, Illinois


### PR DESCRIPTION
The location: Gwagwalada located in Abuja, Nigeria has been added to the list. It is one of the cities in the Federal Capital Territory.